### PR TITLE
Look for and use the enhanced GNU getopt command

### DIFF
--- a/git-hooks
+++ b/git-hooks
@@ -24,6 +24,20 @@ GITHOOKS=(
     post-rewrite
 )
 
+set +e
+getopt -T &>/dev/null
+set -e
+if [[ $? -eq 4 ]]; then
+    getopt=getopt
+else
+    getopt="$(brew --prefix gnu-getopt &>/dev/null || command -v port &>/dev/null && echo /opt/local || echo /usr/local)/bin/getopt"
+fi
+
+if !command -v $getopt &>/dev/null ; then
+    echo "Could not find GNU getopt. Exiting." >&2
+    exit 1
+fi
+
 # HELP
 #############################################
 read -r -d '' HELP <<'HELP' || :
@@ -232,7 +246,7 @@ function git_hooks__extract_help {
 function git_hooks__extract_doc {
     local doc_type
 
-    eval set -- "$(getopt -o ah -- $@)"
+    eval set -- "$($getopt -o ah -- $@)"
     while [[ $1 != -- ]]; do
         case $1 in
             -a) doc_type=ARGS; shift;;
@@ -286,7 +300,7 @@ HELP
 
     local link item answer firsttime examples=false no_preserve=false
 
-    eval set -- "$(getopt -o e --long examples,no-preserve -- $@)"
+    eval set -- "$($getopt -o e --long examples,no-preserve -- $@)"
     while [[ $1 != -- ]]; do
         case $1 in
             -e|--examples) examples=true; shift;;
@@ -732,7 +746,7 @@ HELP
 
     local name quiet=false
 
-    eval set -- "$(getopt -o q --long quiet -- "$@")"
+    eval set -- "$($getopt -o q --long quiet -- "$@")"
     while [[ $1 != -- ]]; do
         case $1 in
             -q|--quiet) quiet=true; shift;;
@@ -766,7 +780,7 @@ HELP
 
     local name quiet=false
 
-    eval set -- "$(getopt -o q --long quiet -- "$@")"
+    eval set -- "$($getopt -o q --long quiet -- "$@")"
     while [[ $1 != -- ]]; do
         case $1 in
             -q|--quiet) quiet=true; shift;;
@@ -799,7 +813,7 @@ HELP
 
     local hook name path
 
-    eval set -- "$(getopt -o q --long quiet -- "$@")"
+    eval set -- "$($getopt -o f --long force -- "$@")"
     while [[ $1 != -- ]]; do
         case $1 in
             -f|--force) export GITHOOKS_RUN=true; shift;;

--- a/git-hooks
+++ b/git-hooks
@@ -33,7 +33,9 @@ elif brew --prefix gnu-getopt &>/dev/null; then
     getopt=$(brew --prefix gnu-getopt)/bin/getopt
 elif command -v port &>/dev/null; then
     getopt=/opt/local/bin/getopt
-else
+fi
+
+if !command -v $getopt &>/dev/null ; then
     echo "Could not find GNU getopt. Exiting." >&2
     exit 1
 fi

--- a/git-hooks
+++ b/git-hooks
@@ -28,12 +28,12 @@ set +e
 getopt -T &>/dev/null
 set -e
 if [[ $? -eq 4 ]]; then
-    export getopt=getopt
+    getopt=getopt
+elif brew --prefix gnu-getopt &>/dev/null; then
+    getopt=$(brew --prefix gnu-getopt)/bin/getopt
+elif command -v port &>/dev/null; then
+    getopt=/opt/local/bin/getopt
 else
-    export getopt="$(brew --prefix gnu-getopt &>/dev/null || command -v port &>/dev/null && echo /opt/local || echo /usr/local)/bin/getopt"
-fi
-
-if !command -v $getopt &>/dev/null ; then
     echo "Could not find GNU getopt. Exiting." >&2
     exit 1
 fi

--- a/git-hooks
+++ b/git-hooks
@@ -34,8 +34,8 @@ elif brew --prefix gnu-getopt &>/dev/null; then
 elif command -v port &>/dev/null; then
     getopt=/opt/local/bin/getopt
 fi
-
-if !command -v $getopt &>/dev/null ; then
+echo $getopt
+if !command -v $getopt &>/dev/null; then
     echo "Could not find GNU getopt. Exiting." >&2
     exit 1
 fi

--- a/git-hooks
+++ b/git-hooks
@@ -28,9 +28,9 @@ set +e
 getopt -T &>/dev/null
 set -e
 if [[ $? -eq 4 ]]; then
-    getopt=getopt
+    export getopt=getopt
 else
-    getopt="$(brew --prefix gnu-getopt &>/dev/null || command -v port &>/dev/null && echo /opt/local || echo /usr/local)/bin/getopt"
+    export getopt="$(brew --prefix gnu-getopt &>/dev/null || command -v port &>/dev/null && echo /opt/local || echo /usr/local)/bin/getopt"
 fi
 
 if !command -v $getopt &>/dev/null ; then

--- a/git-hooks
+++ b/git-hooks
@@ -24,21 +24,32 @@ GITHOOKS=(
     post-rewrite
 )
 
+
+# GETOPT
+#############################################
+# We depend on GNU getopt for option parsing, but we don't expect
+# OSX users to install it over their built-in getopt command.
+
 set +e
 getopt -T &>/dev/null
-set -e
 if [[ $? -eq 4 ]]; then
     getopt=getopt
 elif brew --prefix gnu-getopt &>/dev/null; then
     getopt=$(brew --prefix gnu-getopt)/bin/getopt
 elif command -v port &>/dev/null; then
     getopt=/opt/local/bin/getopt
-fi
-echo $getopt
-if !command -v $getopt &>/dev/null; then
+else
     echo "Could not find GNU getopt. Exiting." >&2
     exit 1
 fi
+
+# Final check because 'brew --prefix' can return a path that points to nothing.
+if ! command -v $getopt &>/dev/null; then
+    echo "Could not find GNU getopt. Exiting." >&2
+    exit 1
+fi
+set -e
+
 
 # HELP
 #############################################
@@ -748,7 +759,7 @@ HELP
 
     local name quiet=false
 
-    eval set -- "$($getopt -o q --long quiet -- "$@")"
+    eval set -- "$($getopt -o q --long quiet -- $@)"
     while [[ $1 != -- ]]; do
         case $1 in
             -q|--quiet) quiet=true; shift;;
@@ -782,7 +793,7 @@ HELP
 
     local name quiet=false
 
-    eval set -- "$($getopt -o q --long quiet -- "$@")"
+    eval set -- "$($getopt -o q --long quiet -- $@)"
     while [[ $1 != -- ]]; do
         case $1 in
             -q|--quiet) quiet=true; shift;;
@@ -815,7 +826,7 @@ HELP
 
     local hook name path
 
-    eval set -- "$($getopt -o f --long force -- "$@")"
+    eval set -- "$($getopt -o f --long force -- $@)"
     while [[ $1 != -- ]]; do
         case $1 in
             -f|--force) export GITHOOKS_RUN=true; shift;;


### PR DESCRIPTION
This allows for long option names to our sub-commands.

This does not assume the user has replaced their standard
`getopt` command with the GNU version. It just looks for it
in the conventional locations for `brew` and `macports`
installations.